### PR TITLE
Handle missing user email in VideoProcessingSucceeded handler

### DIFF
--- a/src/Postech.Fiap.Hackathon.VideoProcessing.Worker/Features/Videos/VideoProcessor/Commands/VideoProcessorCommandHandler.cs
+++ b/src/Postech.Fiap.Hackathon.VideoProcessing.Worker/Features/Videos/VideoProcessor/Commands/VideoProcessorCommandHandler.cs
@@ -82,11 +82,11 @@ public class VideoProcessorCommandHandler(
             await videoRepository.ChangeStatusAsync(video.Id.ToString(), VideoStatus.Processed, cancellationToken);
             logger.LogInformation("Status do vídeo alterado para 'Processado'. ID: {VideoId}", video.Id);
 
-            // logger.LogInformation("Publicando notificação de sucesso do processamento do vídeo. ID: {VideoId}",
-            //     video.Id);
-            // await mediator.Publish(new VideoProcessingSucceededNotification(video.Id), cancellationToken);
-            // logger.LogInformation(
-            //     "Notificação de sucesso do processamento do vídeo publicada com sucesso. ID: {VideoId}", video.Id);
+            logger.LogInformation("Publicando notificação de sucesso do processamento do vídeo. ID: {VideoId}",
+                video.Id);
+            await mediator.Publish(new VideoProcessingSucceededNotification(video.Id), cancellationToken);
+            logger.LogInformation(
+                "Notificação de sucesso do processamento do vídeo publicada com sucesso. ID: {VideoId}", video.Id);
 
             return Result.Success();
         }

--- a/src/Postech.Fiap.Hackathon.VideoProcessing.Worker/Features/Videos/VideoProcessor/Notifications/VideoProcessingSucceededNotificationHandler.cs
+++ b/src/Postech.Fiap.Hackathon.VideoProcessing.Worker/Features/Videos/VideoProcessor/Notifications/VideoProcessingSucceededNotificationHandler.cs
@@ -17,6 +17,12 @@ public class VideoProcessingSucceededNotificationHandler(
 
         var userEmail = await userRepository.GetUserEmailByVideoId(videoId);
 
+        if (string.IsNullOrWhiteSpace(userEmail))
+        {
+            logger.LogWarning("E-mail do usuário não encontrado para VideoId {VideoId}", notification.VideoId);
+            return;
+        }
+
         try
         {
             await emailSender.SendAsync(

--- a/src/Postech.Fiap.Hackathon.VideoProcessing.Worker/Infrastructure/Email/SmtpEmailSender.cs
+++ b/src/Postech.Fiap.Hackathon.VideoProcessing.Worker/Infrastructure/Email/SmtpEmailSender.cs
@@ -12,6 +12,13 @@ public class SmtpEmailSender(IOptions<SmtpSettings> options) : IEmailSender
 
     public async Task SendAsync(string to, string subject, string body, CancellationToken cancellationToken)
     {
+        if (string.IsNullOrWhiteSpace(to))
+            throw new ArgumentException("O endereço de e-mail do destinatário não pode ser nulo ou vazio.", nameof(to));
+
+        if (string.IsNullOrWhiteSpace(_settings.From))
+            throw new ArgumentException("O endereço de e-mail do remetente não pode ser nulo ou vazio.",
+                nameof(_settings.From));
+
         var message = new MailMessage
         {
             From = new MailAddress(_settings.From),


### PR DESCRIPTION
Add a check to log a warning and exit early if the user's email cannot be found by video ID. This prevents unnecessary processing and avoids potential errors when attempting to send an email.